### PR TITLE
Hard-codes the old (2008) slide design in the TeX template

### DIFF
--- a/slides.tex
+++ b/slides.tex
@@ -14,6 +14,7 @@
 	authorontitle=true,
 	usepdftitle=false,
 %	pdfa=false,
+	design=2008,
 	]{tudabeamer}
 \usepackage[main=english]{babel}
 


### PR DESCRIPTION
This PR hard-codes the old (2018) slide design (including the blue bars, etc.) within the LaTeX template this repository provides to our students.

I've tested it on:
- latexmk with TeX Live 2024 headlessly (native)
- texstudio with TeX Live 2024
- Overleaf
- https://sharelatex.tu-darmstadt.de
- Docker [maxkratz/texlive:2023](https://hub.docker.com/r/maxkratz/texlive/tags)
- Docker [maxkratz/texlive:2024](https://hub.docker.com/r/maxkratz/texlive/tags)